### PR TITLE
タスクの削除、更新ができない不具合を修正

### DIFF
--- a/src/components/Item.jsx
+++ b/src/components/Item.jsx
@@ -94,8 +94,6 @@ const Item = ( {todo} ) => {
       ref={setNodeRef}
       {...attributes}
       {...listeners}
-      {...transform}
-      {...transition}
       style={style}
     >
       <button className="c-button" onClick={() => complete(todo)}>完了</button>

--- a/src/components/Todo.jsx
+++ b/src/components/Todo.jsx
@@ -27,7 +27,7 @@ const Todo = () => {
   const { todos, setTodos } = useTodoContext();
 
   const sensors = useSensors(
-    useSensor(PointerSensor),
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
   );
 
   const handleDragEnd = async (event) => {


### PR DESCRIPTION
タスクの削除、更新ができるようにしました。
クリックしてもドラッグ判定となっていたので、5px（多分）動いたらドラッグと判定させるようにしています
 - (参考): https://qiita.com/taka-k/items/f1d0f1c082437d439df4

また、別件でtransition, transformをおそらく誤って記述していてconsoleでエラーが出てたので削除しています。
（公式ページに記述がなく、試しに消したらエラー消えたって感じなのでもし何かにこの記述がしてあるのであれば教えてください）



...ちなみに現状順序入れ替えをputで行おうとしていますが、単体のTODOを更新することしかできなそうです。
https://qiita.com/ryome/items/36da51f0f5973eab8720#json-server%E8%B5%B7%E5%8B%95

並び替えした順序をDBに保存するのは他の人も苦労していそう！
https://zenn.dev/itte/articles/e97002637cd3a6
自分が手抜きで作るなら↑の記事の方法6かな〜って感じです